### PR TITLE
call AWS::IAM for the username if not set in the ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+fixtures/vcr_cassettes/*
+fixtures/ssh_config/*
+config/pizza_cone.rb
 
 ## Specific to RubyMotion:
 .dat*

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ bundle install
 
 ## Configuration
 
+### AWS CLI access: The easy way
+
+Set up the [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html). Pizza cone will pick up your settings.
+
+If you're getting *Aws::IAM::Errors::AccessDenied* from pizza cone, that means you don't have rights to run IAM requests. In that case, either obtain those rights or add your Opsworks SSH Username to the .env file:
+
+AWS_SSH_USERNAME="yourawssshusername"
+
+### AWS CLI access: The hard way
+
+If the easy way didn't work, here is the detailed setup:
+
 Copy .env.sample to .env and edit it:
 
 ```

--- a/config/pizza_cone.rb.example
+++ b/config/pizza_cone.rb.example
@@ -1,4 +1,3 @@
-# use files from fixtures for tests
 PizzaCone.configure do |config|
   config.define_instance_hostname_block do |instance|
     "#{instance.hostname} #{instance.stack_name}-#{instance.hostname}"

--- a/lib/pizza_cone/iam_wrapper.rb
+++ b/lib/pizza_cone/iam_wrapper.rb
@@ -1,0 +1,23 @@
+module PizzaCone
+  class IAMWrapper
+    DOT = "."
+
+    class << self
+      def opsworks_ssh_username
+        new.opsworks_ssh_username
+      end
+    end
+
+    def initialize
+      @iam = Aws::IAM::Client.new(region: "us-east-1")
+    end
+
+    def opsworks_ssh_username
+      user.user_name.delete(DOT)
+    end
+
+    def user
+      @user ||= @iam.get_user.user
+    end
+  end
+end

--- a/lib/pizza_cone/instance_wrapper.rb
+++ b/lib/pizza_cone/instance_wrapper.rb
@@ -1,9 +1,10 @@
 require "delegate"
+require_relative "./iam_wrapper"
 
 module PizzaCone
   class InstanceWrapper < SimpleDelegator
     ACCESSIBLE_STATUSES = %w(online running_setup setup_failed)
-    USERNAME = ENV.fetch("AWS_SSH_USERNAME")
+    USERNAME =  ENV.fetch("AWS_SSH_USERNAME", IAMWrapper.opsworks_ssh_username)
 
     attr_reader :stack
 

--- a/spec/pizza_cone/iam_wrapper_spec.rb
+++ b/spec/pizza_cone/iam_wrapper_spec.rb
@@ -1,0 +1,16 @@
+describe PizzaCone::IAMWrapper do
+  use_vcr_cassette
+
+  describe ".opsworks_ssh_username" do
+    let(:user) do
+      iam = Aws::IAM::Client.new(region: "us-east-1")
+      iam.get_user.user
+    end
+
+    subject { described_class.opsworks_ssh_username }
+
+    it "returns your IAM username with all the dots removed" do
+      expect(subject).to eq(user.user_name.delete("."))
+    end
+  end
+end


### PR DESCRIPTION
if you have permissions to call IAM, derive the ssh username for opsworks from the IAM user data
